### PR TITLE
Update readme.md

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -94,6 +94,7 @@ Clone whoisdigger code and install dependencies
 
 ```
 git clone https://github.com/whois-team/whoisdigger
+cd whoisdigger
 npm install
 ```
 


### PR DESCRIPTION
I updated it so it the readme.md file shows you have to enter the whoisdigger directory before running `npm install`.